### PR TITLE
feat: Add clusterId to Annotation and iOS MapKit clustering

### DIFF
--- a/ios/Classes/Annotations/AnnotationController.swift
+++ b/ios/Classes/Annotations/AnnotationController.swift
@@ -34,6 +34,13 @@ extension AppleMapController: AnnotationDelegate {
     public func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
         if annotation is MKUserLocation {
             return nil
+        }
+        if #available(iOS 11.0, *), let cluster = annotation as? MKClusterAnnotation {
+            mapView.register(MKMarkerAnnotationView.self, forAnnotationViewWithReuseIdentifier: MKMapViewDefaultClusterAnnotationViewReuseIdentifier)
+            let v = mapView.dequeueReusableAnnotationView(withIdentifier: MKMapViewDefaultClusterAnnotationViewReuseIdentifier, for: cluster) as! MKMarkerAnnotationView
+            v.glyphText = "\(cluster.memberAnnotations.count)"
+            v.canShowCallout = false
+            return v
         } else if let flutterAnnotation = annotation as? FlutterAnnotation {
             return self.getAnnotationView(annotation: flutterAnnotation)
         }
@@ -245,6 +252,10 @@ extension AppleMapController: AnnotationDelegate {
             pinAnnotationView = MKPinAnnotationView.init(annotation: annotation, reuseIdentifier: id)
         }
         pinAnnotationView.layer.zPosition = annotation.zIndex
+        
+        if #available(iOS 11.0, *) {
+            pinAnnotationView.clusteringIdentifier = annotation.clusterId
+        }
 
         if let hueColor: Double = annotation.icon.hueColor {
             pinAnnotationView.pinTintColor = UIColor.init(hue: hueColor, saturation: 1, brightness: 1, alpha: 1)
@@ -258,6 +269,7 @@ extension AppleMapController: AnnotationDelegate {
         self.mapView.register(FlutterMarkerAnnotationView.self, forAnnotationViewWithReuseIdentifier: id)
         let markerAnnotationView: FlutterMarkerAnnotationView = self.mapView.dequeueReusableAnnotationView(withIdentifier: id, for: annotation) as! FlutterMarkerAnnotationView
         markerAnnotationView.stickyZPosition = annotation.zIndex
+        markerAnnotationView.clusteringIdentifier = annotation.clusterId
 
         if let hueColor: Double = annotation.icon.hueColor {
             markerAnnotationView.markerTintColor = UIColor.init(hue: hueColor, saturation: 1, brightness: 1, alpha: 1)
@@ -276,6 +288,9 @@ extension AppleMapController: AnnotationDelegate {
         }
         annotationView.image = annotation.icon.image
         annotationView.stickyZPosition = annotation.zIndex
+        if #available(iOS 11.0, *) {
+            annotationView.clusteringIdentifier = annotation.clusterId
+        }
         return annotationView
     }
 

--- a/ios/Classes/Annotations/FlutterAnnotation.swift
+++ b/ios/Classes/Annotations/FlutterAnnotation.swift
@@ -23,6 +23,7 @@ class FlutterAnnotation: NSObject, MKAnnotation {
     var zIndex: Double = -1
     var calloutOffset: Offset = Offset()
     var icon: AnnotationIcon = AnnotationIcon.init()
+    var clusterId: String?
     var selectedProgrammatically: Bool = false
     
     public init(fromDictionary annotationData: Dictionary<String, Any>, registrar: FlutterPluginRegistrar) {
@@ -35,6 +36,7 @@ class FlutterAnnotation: NSObject, MKAnnotation {
         self.subtitle = infoWindow["snippet"] as? String
         self.infoWindowConsumesTapEvents = infoWindow["consumesTapEvents"] as? Bool ?? false
         self.id = annotationData["annotationId"] as? String
+        self.clusterId = annotationData["clusterId"] as? String
         self.isVisible = annotationData["visible"] as? Bool
         self.isDraggable = annotationData["draggable"] as? Bool
         if let zIndex = annotationData["zIndex"] as? Double {

--- a/lib/src/annotation.dart
+++ b/lib/src/annotation.dart
@@ -155,6 +155,7 @@ class Annotation {
     this.visible = true,
     this.zIndex = -1,
     this.onDragEnd,
+    this.clusterId,
   }) : assert(0.0 <= alpha && alpha <= 1.0);
 
   /// Uniquely identifies a [Annotation].
@@ -186,6 +187,9 @@ class Annotation {
   /// Geographical location of the annotation.
   final LatLng position;
 
+  /// Optional cluster identifier. When set, MapKit may cluster annotations with the same id.
+  final String? clusterId;
+
   /// Callbacks to receive tap events for annotations placed on this map.
   final VoidCallback? onTap;
 
@@ -215,6 +219,7 @@ class Annotation {
     double? zIndexParam,
     VoidCallback? onTapParam,
     ValueChanged<LatLng>? onDragEndParam,
+    String? clusterIdParam,
   }) {
     return Annotation(
       annotationId: annotationId,
@@ -228,6 +233,7 @@ class Annotation {
       visible: visibleParam ?? visible,
       zIndex: zIndexParam ?? zIndex,
       onDragEnd: onDragEndParam ?? onDragEnd,
+      clusterId: clusterIdParam ?? clusterId,
     );
   }
 
@@ -249,6 +255,7 @@ class Annotation {
     addIfPresent('visible', visible);
     addIfPresent('position', position._toJson());
     addIfPresent('zIndex', zIndex);
+    addIfPresent('clusterId', clusterId);
     return json;
   }
 


### PR DESCRIPTION
This PR adds first-class clustering support for Apple Maps.

Changes
- Dart: Add optional `clusterId` field to `Annotation`, include in JSON serialization
- iOS (Swift):
  - Parse `clusterId` in `FlutterAnnotation`
  - Set `clusteringIdentifier` on pin/marker/custom annotation views
  - Provide a default `MKClusterAnnotation` view with count badge (Material-like)

Why
- Enables selectively clustering annotations by assigning the same `clusterId`
- Backed by native MapKit clustering (iOS 11+)

Usage (app side)
```dart
final isFirstLevel = assetPath.endsWith('assets/images/markers/first_level_asset_purple.svg') ||
                     assetPath.endsWith('assets/images/markers/first_level_asset_gray.svg');

final ann = Annotation(
  annotationId: AnnotationId(id),
  position: position,
  icon: yourIcon,
  // ...
  clusterId: isFirstLevel ? 'firstLevelAssets' : null,
);
```

Notes
- Clustering works on iOS 11+ only. Guards are in place.
- No breaking changes: `clusterId` is optional.

If desired, we can theme the cluster marker (tint/glyph) to match your design system.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author